### PR TITLE
fix(*): windows opencv issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ imageio==2.34.1
 imageio-ffmpeg==0.4.9
 moviepy==1.0.3
 numpy==1.26.4
-opencv-python==4.9.0.80
+opencv-python==4.10.0.84
 pillow==10.3.0
 proglog==0.1.10
 requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ idna==3.7
 imageio==2.34.1
 imageio-ffmpeg==0.4.9
 moviepy==1.0.3
-numpy==1.24.4
+numpy==1.26.4
 opencv-python==4.9.0.80
 pillow==10.3.0
 proglog==0.1.10

--- a/src/main.py
+++ b/src/main.py
@@ -21,15 +21,18 @@ def download(url, file_name_no_ext):
 
 
 # Fetch some generic images from the internet and store them as local files
-# on /tmp directory.
+# on temporary directory.
 fb_logo = "https://static.xx.fbcdn.net/rsrc.php/v3/y0/r/eFZD1KABzRA.png"
 ig_logo = "https://static.cdninstagram.com/rsrc.php/v3/yM/r/7xwrlYffOBb.png"
 
 image_urls = [fb_logo, ig_logo]
 image_paths = []
 
+# Declare temporary pathname depending on running OS.
+temp_path = "/tmp" if os.name == 'posix' else f"{os.path.expanduser("~")}/AppData/Local/Temp"
+
 for i, url in enumerate(image_urls):
-    file_name = download(url, f"/tmp/{i}")
+    file_name = download(url, f"{temp_path}/{i}")
     image_paths.append(file_name)
 
 # Create a new source that will slide through these images
@@ -48,7 +51,7 @@ slideshow_source = ImageSlideshowSource(
 
 # Now we will configure a larger WhatsApp logo to be used as background.
 wa_logo = "https://static.whatsapp.net/rsrc.php/v3/yP/r/rYZqPCBaG70.png"
-wa_image_path = download(wa_logo, "/tmp/bg")
+wa_image_path = download(wa_logo, f"{temp_path}/bg_0")
 
 bg_source = SingleMediaSource(
     wa_image_path,
@@ -64,15 +67,20 @@ combinator_source = MarginCombinator(
 )
 
 
-# Download an audio file from Meta's Sound Collection
-audio_url = "https://scontent.faep8-2.fna.fbcdn.net/v/t39.12897-6/406204921_873681674389419_4350045728225354598_n.wav/Bling-Reels-Sound-Listicle.wav?_nc_cat=108&ccb=1-7&_nc_sid=c2de2f&_nc_ohc=BYS1Nl_5SSMAb519o5h&_nc_ht=scontent.faep8-2.fna&oh=00_AfCMXJ8LklE5_tjeglEy_ScNQX3sGWw95ac-3n4xU2hjnw&oe=662C6FB6&dl=1"
-audio_path = download(audio_url, "/tmp/audio")
+# Use a sample audio file from Meta's Audio Collection.
+audio_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'sample-audio.wav')
 
-# Create a new video with the source and save it to /tmp directory.
+# If you wish to download an audio file off the internet instead, uncomment the following lines and comment out the one above.
+# audio_url = "https://www.sample-videos.com/audio/mp3/crowd-cheering.mp3"
+# audio_path = download(audio_url, f"{temp_path}/audio")
+
+# Create a new video with the source and save it to temporary directory.
 sink = Sink(
     source=combinator_source,
     target_fps=60,
     time=20,
-    output_video_path="sample.mp4"
+    output_video_path="sample.mp4",
+    temp_file_path=f"{temp_path}/tmp.mp4"
 )
+
 sink.create_video(audio_path)

--- a/src/sink.py
+++ b/src/sink.py
@@ -11,9 +11,9 @@ class Sink():
     A class to create a video from a source and add audio if provided.
     """
 
-    TEMP_FILE = "/tmp/tmp.mp4"
+    TEMP_FILE = ""
 
-    def __init__(self, source: source.Source, target_fps=60, time=15, output_video_path="sample.mp4"):
+    def __init__(self, source: source.Source, target_fps=60, time=15, output_video_path="sample.mp4", temp_file_path=""):
         """
         Initializes the Sink class with the source, target fps, time, and output video path.
         Args:
@@ -26,6 +26,8 @@ class Sink():
         self.target_fps = target_fps
         self.time = time
         self.output_video_path = output_video_path
+        
+        Sink.TEMP_FILE = temp_file_path
 
     def _add_audio(self, audio_path):
         """
@@ -61,6 +63,9 @@ class Sink():
         height, width = img.shape[:2]
         
         vw = cv2.VideoWriter(output_video_path, cv2.VideoWriter_fourcc(*'mp4v'), target_fps, (width, height))
+
+        if not vw.isOpened():
+            raise Exception("OpenCV cannot recognize the codec used by the temporary video.")
 
         for fr in range(time * target_fps):
             vw.write(img)


### PR DESCRIPTION
## Problem
- Cloning the sample project and installing its requirements on latest Windows machines causes a bad build for `numpy` due to an old version no longer supported on the latest Python version 3.12.4.
- Sample project points to `/tmp` folder only, failing to save downloaded files on Windows machines.
- Running the project as-is would cause an OpenCV `VideoCapture` exception failing to find a decoder for `codec_id=61` (PNG) thus not reading the alpha channel on the RGBA sample image file.
```
[ERROR:0@0.002] global cap_ffmpeg_impl.hpp:1268 open Could not find decoder for codec_id=61
[ERROR:0@0.002] global cap_ffmpeg_impl.hpp:1317 open VIDEOIO/FFMPEG: Failed to initialize VideoCapture
```

## Solution
- `requirements.txt` has been adjusted to use dependency versions that support current OS builds.
- The project differentiates running operating system to adjust temporary files' pathnames and use an `cv2.imread` strategy to read image files that present an alpha channel and are on Windows, else reverts to using `cv2.VideoCapture` as seen on commit https://github.com/fbsamples/video-template-builder/commit/e989b7868f516b7d47a59723b3f1a2ec1e990dfa

## Pending
- A strategy should be implemented in place to correctly manage image alpha channels.